### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo DOCKER_TAG=$(echo pr-${GITHUB_SHA:0:8}) >> $GITHUB_ENV
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@a0b8f0e2d777562c13523b9a4d9480bae383486b
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           RELEASE_VERSION: '${{ env.DOCKER_TAG }}'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             }
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@a0b8f0e2d777562c13523b9a4d9480bae383486b
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: lostpixel/lost-pixel
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore